### PR TITLE
Add Deck Display in Bins and Sorting

### DIFF
--- a/docs/sort_structure.md
+++ b/docs/sort_structure.md
@@ -1,0 +1,18 @@
+# sorted_cards Structure
+
+```javascript
+{
+	bins: {
+		a: { bins: {
+				d: ['card1', 'card2', 'card3'],
+				e: ['card4', 'card5', 'card6'],
+				f: ...
+			},
+			labels: ['d', 'e', 'f']
+		},
+		b: { },
+		c: { },
+	},
+	labels: ['a', 'b', 'c']
+}
+```

--- a/src/components/deck_view.js
+++ b/src/components/deck_view.js
@@ -1,15 +1,36 @@
 import React, { Component } from 'react';
 import Card from './card.js';
 import PropTypes from 'prop-types';
+import { deep_sort } from '../utils/sort.js';
 
 class DeckView extends Component {
+
+	state = {
+		sorts: [ 'cmc' ],
+	};
+
+	generate_bins = ( sorted_cards, depth ) => {
+		if ( Array.isArray( sorted_cards ) ) {
+			return sorted_cards.map( ( card, index ) =>
+				<Card card={card} key={index} />
+			);
+		}
+		return sorted_cards.labels.map( ( label, index ) => {
+			return (
+				<div key={index} className={depth ? 'sub-category' : 'category'}>
+					<h3 style={{textAlign: 'center'}}>{label}</h3>
+					{this.generate_bins( sorted_cards.bins[label], true )}
+				</div>
+			);
+		} );
+		
+	};
 	
 	render() {
+		const sorted_cards = deep_sort( this.props.cards, this.state.sorts );
 		return (
 			<div id='maindeck'>
-				{this.props.cards.map( ( card, index ) => (
-					<Card card={card} key={index} />
-				) ) }
+				{this.generate_bins( sorted_cards )}
 			</div>
 		);
 	}

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -1,0 +1,64 @@
+const alphaCompare = ( a, b ) => {
+	return a.name <= b.name ? -1 : 1;
+};
+
+const sort_into_label = ( card, sort_type ) => {
+	switch( sort_type ) {
+	case 'cmc':
+		if( card.convertedManaCost < 8 ) return card.convertedManaCost.toString();
+		else return '8+';
+	}
+};
+
+const get_sorted_labels = ( bins, sort_type ) => {
+	let sort_func;
+	switch( sort_type ) {
+	case 'cmc':
+		sort_func = ( a, b ) => {
+			return parseInt( a ) - parseInt ( b );
+		};
+		break;
+	default:
+		sort_func = alphaCompare;
+		break;
+	}
+	return Object.keys( bins ).sort( sort_func );
+};
+
+const bin_sort = ( cards, sort_type ) => {
+	let bins = {};
+
+	cards.forEach( ( card ) => {
+		const label = sort_into_label( card, sort_type );
+		if ( !bins[label] ) {
+			bins[label] = [];
+		}
+		bins[label].push( card );
+	} );
+
+	return { bins: bins, labels: get_sorted_labels( bins, sort_type ) };
+};
+
+const deep_sort = ( cards, sorts ) => {
+	if( sorts.length === 0 ) {
+		return cards.sort( alphaCompare );
+	}
+
+	const [primary, ...others] = sorts;
+	
+	const sort_result = bin_sort( cards, primary );
+
+	for ( const label of sort_result.labels ) {
+		if ( others.length > 0 ) {
+			sort_result.bins[label] = bin_sort( sort_result.bins[label], others );
+		} else {
+			sort_result.bins[label].sort( alphaCompare );
+		}
+	}
+
+	return sort_result;
+	
+};
+
+
+export { deep_sort };


### PR DESCRIPTION
Added support for displaying cards added to deck as well as multi
level sorting. The only thing left to be done is to implement more
sorts, create a UI element for choosing primary, sub, and potentially
tertiary sort, and then creating CSS for sub-category